### PR TITLE
Fix #1

### DIFF
--- a/src/libtfhe/fft_processors/nayuki/fft_processor_nayuki.cpp
+++ b/src/libtfhe/fft_processors/nayuki/fft_processor_nayuki.cpp
@@ -12,7 +12,7 @@ FFT_Processor_nayuki::FFT_Processor_nayuki(const int32_t N): _2N(2*N),N(N),Ns2(N
     tables_reverse = fft_init_reverse(_2N);
     omegaxminus1 = (cplx*) malloc(sizeof(cplx) * _2N);
     for (int32_t x=0; x<_2N; x++) {
-	omegaxminus1[x]=cos(x*M_PI/N)-1. + sin(x*M_PI/N) * 1i; 
+	omegaxminus1[x]=cplx(cos(x*M_PI/N)-1., sin(x*M_PI/N)); // instead of cos(x*M_PI/N)-1. + sin(x*M_PI/N) * 1i 
 	//exp(i.x.pi/N)-1
     }
 }


### PR DESCRIPTION
Fixes the issue with compiling on Mac

The nayuki processor must be updated to use the `cplx` macro to create complex numbers. The corresponding line for fftw can be found here:

https://github.com/ilachill/MK-TFHE/blob/master/src/libtfhe/fft_processors/fftw/fft_processor_fftw.cpp#L18